### PR TITLE
 Improve performance and add lazy_fomat macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "fomat-macros"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Michał Krasnoborski <mkrdln@gmail.com>"]
 
 description = "Alternative syntax for print/write/format-like macros with a small templating language"
 
-documentation = "https://docs.rs/fomat-macros/0.3.0/fomat_macros/"
+documentation = "https://docs.rs/fomat-macros/0.3.1/fomat_macros/"
 repository = "https://github.com/krdln/fomat-macros"
 readme = "README.md"
 keywords = ["macro", "print", "template", "format", "interpolation"]

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ What was the motivation to create this crate?
   ```
 
 * Speed! `fomat!` may be faster than `format!`
-  (see `cargo bench`).
-  That's because of optimization of how string literals
-  are handled.
+  (see `cargo bench`). That's because there's
+  just one virtual call for single invocation
+  of `fomat!` instead of one per each argument
+  in `std::format!`.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fomat-macros = "0.3.0"
+fomat-macros = "0.3.1"
 ```
 
 And `use` the macros in your `.rs` file, eg.:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -29,6 +29,26 @@ fn short_format(b: &mut Bencher) {
 }
 
 #[bench]
+fn two_fomat(b: &mut Bencher) {
+    b.iter(|| fomat!("One"(3)(2+2)))
+}
+
+#[bench]
+fn two_format(b: &mut Bencher) {
+    b.iter(|| format!("One{}{}", 3, 2+2))
+}
+
+#[bench]
+fn three_fomat(b: &mut Bencher) {
+    b.iter(|| fomat!("One"(2)(3)(2+2)))
+}
+
+#[bench]
+fn three_format(b: &mut Bencher) {
+    b.iter(|| format!("One{}{}{}", 2, 3, 2+2))
+}
+
+#[bench]
 fn long_fomat(b: &mut Bencher) {
     let world = "world";
     b.iter(|| fomat!(


### PR DESCRIPTION
Instead of calling `write!` for each interpolated argument, now the whole format-expression is wrapped inside a struct with a `Display::fmt` implementation. This makes a `fmt::Formater`
available to us, so we can call `Display`/`Debug::fmt` implementations of interpolated expressions directly. This results in about 20% speedup in larger format-expressions (because we don't have to
go through `format_args` machinery all the time). Unfortunately, this also slows down a little bit short format-expression (with 0 or 1 interpolated expressions), but this seems like a reasonable compromise.

This commit also adds a `DisplayFn` struct and `lazy_format` macro that uses the same syntax as `fomat` but returns a displayable struct instead of `String`.

Thanks @rust-iendo and @djc for [benchmarks](https://github.com/rust-iendo/template-benchmarks-rs) which inspired me to seek how to improve perf.